### PR TITLE
Renamed "HalfOpen" to "HalfClosed" 

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -7,7 +7,7 @@ image:https://travis-ci.org/javaslang/javaslang-circuitbreaker.svg?branch=master
 This library is a lightweight, easy-to-use fault tolerance library inspired by https://github.com/Netflix/Hystrix[Netflix Hystrix], but designed solely for Java 8 and functional programming. Lightweight, because the library only uses SLF4J and a functional library for Java 8 called https://github.com/javaslang/javaslang[Javaslang]. Javaslang itself has no external library dependencies. 
 The library provides several higher-order functions to decorate any function with a http://martinfowler.com/bliki/CircuitBreaker.html[Circuit Breaker]. In the following I call the higher-order functions decorators. The decorators return an enhanced version of your function. Furthermore, the library provides a decorator to retry failed functions. You can stack more than one decorator on any given function. That means, you can combine a Retry decorator with a CircuitBreaker decorator. Any decorated function can be invoked synchronously or asynchronously.
 
-The CircuitBreaker is implemented via a finite state machine with three states: `CLOSED`, `OPEN` and `HALF_OPEN`.
+The CircuitBreaker is implemented via a finite state machine with three states: `CLOSED`, `OPEN` and `HALF_CLOSED`.
 
 image::src/docs/asciidoc/images/state_machine.jpg[]
 

--- a/src/docs/asciidoc/usage_guide.adoc
+++ b/src/docs/asciidoc/usage_guide.adoc
@@ -24,7 +24,7 @@ As an alternative you can provide your own custom global `CircuitBreakerConfig`.
 CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
     .failureRateThreshold(50)
     .waitDurationInOpenState(Duration.ofMillis(1000))
-    .ringBufferSizeInHalfOpenState(2)
+    .ringBufferSizeInHalfClosedState(2)
     .ringBufferSizeInClosedState(2)
     .build();
 

--- a/src/main/java/javaslang/circuitbreaker/CircuitBreakerConfig.java
+++ b/src/main/java/javaslang/circuitbreaker/CircuitBreakerConfig.java
@@ -28,11 +28,11 @@ public class CircuitBreakerConfig {
 
     private static final int DEFAULT_MAX_FAILURE_THRESHOLD = 50; // Percentage
     private static final int DEFAULT_WAIT_DURATION_IN_OPEN_STATE = 60; // Seconds
-    private static final int DEFAULT_RING_BUFFER_SIZE_IN_HALF_OPEN_STATE = 10;
+    private static final int DEFAULT_RING_BUFFER_SIZE_IN_HALF_CLOSED_STATE = 10;
     private static final int DEFAULT_RING_BUFFER_SIZE_IN_CLOSED_STATE = 100;
 
     private final float failureRateThreshold;
-    private int ringBufferSizeInHalfOpenState;
+    private int ringBufferSizeInHalfClosedState;
     private int ringBufferSizeInClosedState;
     private final Duration waitDurationInOpenState;
     private final CircuitBreakerEventListener circuitBreakerEventListener;
@@ -40,13 +40,13 @@ public class CircuitBreakerConfig {
 
     private CircuitBreakerConfig(float failureRateThreshold,
                                  Duration waitDurationInOpenState,
-                                 int ringBufferSizeInHalfOpenState,
+                                 int ringBufferSizeInHalfClosedState,
                                  int ringBufferSizeInClosedState,
                                  Predicate<Throwable> exceptionPredicate,
                                  CircuitBreakerEventListener circuitBreakerEventListener){
         this.failureRateThreshold = failureRateThreshold;
         this.waitDurationInOpenState = waitDurationInOpenState;
-        this.ringBufferSizeInHalfOpenState = ringBufferSizeInHalfOpenState;
+        this.ringBufferSizeInHalfClosedState = ringBufferSizeInHalfClosedState;
         this.ringBufferSizeInClosedState = ringBufferSizeInClosedState;
         this.exceptionPredicate = exceptionPredicate;
         this.circuitBreakerEventListener = circuitBreakerEventListener;
@@ -61,8 +61,8 @@ public class CircuitBreakerConfig {
         return waitDurationInOpenState;
     }
 
-    public int getRingBufferSizeInHalfOpenState() {
-        return ringBufferSizeInHalfOpenState;
+    public int getRingBufferSizeInHalfClosedState() {
+        return ringBufferSizeInHalfClosedState;
     }
 
     public int getRingBufferSizeInClosedState() {
@@ -98,7 +98,7 @@ public class CircuitBreakerConfig {
 
     public static class Builder {
         private int failureRateThreshold = DEFAULT_MAX_FAILURE_THRESHOLD;
-        private int ringBufferSizeInHalfOpenState = DEFAULT_RING_BUFFER_SIZE_IN_HALF_OPEN_STATE;
+        private int ringBufferSizeInHalfClosedState = DEFAULT_RING_BUFFER_SIZE_IN_HALF_CLOSED_STATE;
         private int ringBufferSizeInClosedState = DEFAULT_RING_BUFFER_SIZE_IN_CLOSED_STATE;
         private Duration waitDurationInOpenState = Duration.ofSeconds(DEFAULT_WAIT_DURATION_IN_OPEN_STATE);
         private CircuitBreakerEventListener circuitBreakerEventListener = new DefaultCircuitBreakerEventListener();
@@ -137,20 +137,20 @@ public class CircuitBreakerConfig {
         }
 
         /**
-         * Configures the size of the ring buffer when the CircuitBreaker is half open. The CircuitBreaker stores the success/failure success / failure status of the latest calls in a ring buffer.
+         * Configures the size of the ring buffer when the CircuitBreaker is half closed. The CircuitBreaker stores the success/failure success / failure status of the latest calls in a ring buffer.
          * For example, if {@code ringBufferSizeInClosedState} is 10, then at least 10 calls must be evaluated, before the failure rate can be calculated.
          * If only 9 calls have been evaluated the CircuitBreaker will not trip back to closed or open even if all 9 calls have failed.
          *
          * The size must be greater than 0. Default size is 10.
          *
-         * @param ringBufferSizeInHalfOpenState the size of the ring buffer when the CircuitBreaker is is half open
+         * @param ringBufferSizeInHalfClosedState the size of the ring buffer when the CircuitBreaker is is half closed
          * @return the CircuitBreakerConfig.Builder
          */
-        public Builder ringBufferSizeInHalfOpenState(int ringBufferSizeInHalfOpenState) {
-            if (ringBufferSizeInHalfOpenState < 1 ) {
-                throw new IllegalArgumentException("ringBufferSizeInHalfOpenState must be greater than 0");
+        public Builder ringBufferSizeInHalfClosedState(int ringBufferSizeInHalfClosedState) {
+            if (ringBufferSizeInHalfClosedState < 1) {
+                throw new IllegalArgumentException("ringBufferSizeInHalfClosedState must be greater than 0");
             }
-            this.ringBufferSizeInHalfOpenState = ringBufferSizeInHalfOpenState;
+            this.ringBufferSizeInHalfClosedState = ringBufferSizeInHalfClosedState;
             return this;
         }
 
@@ -207,7 +207,7 @@ public class CircuitBreakerConfig {
             return new CircuitBreakerConfig(
                     failureRateThreshold,
                     waitDurationInOpenState,
-                    ringBufferSizeInHalfOpenState,
+                    ringBufferSizeInHalfClosedState,
                     ringBufferSizeInClosedState,
                     exceptionPredicate,
                     circuitBreakerEventListener);

--- a/src/main/java/javaslang/circuitbreaker/internal/HalfClosedState.java
+++ b/src/main/java/javaslang/circuitbreaker/internal/HalfClosedState.java
@@ -27,7 +27,7 @@ final class HalfClosedState extends CircuitBreakerState {
 
     HalfClosedState(CircuitBreakerStateMachine stateMachine) {
         super(stateMachine);
-        this.circuitBreakerMetrics = new CircuitBreakerMetrics(stateMachine.getCircuitBreakerConfig().getRingBufferSizeInHalfOpenState());
+        this.circuitBreakerMetrics = new CircuitBreakerMetrics(stateMachine.getCircuitBreakerConfig().getRingBufferSizeInHalfClosedState());
         this.failureRateThreshold = stateMachine.getCircuitBreakerConfig().getFailureRateThreshold();
     }
 

--- a/src/test/java/javaslang/circuitbreaker/CircuitBreakerConfigTest.java
+++ b/src/test/java/javaslang/circuitbreaker/CircuitBreakerConfigTest.java
@@ -41,8 +41,8 @@ public class CircuitBreakerConfigTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void ringBufferSizeInHalfOpenStateBelowOneShouldFail() {
-        CircuitBreakerConfig.custom().ringBufferSizeInHalfOpenState(0).build();
+    public void ringBufferSizeInHalfClosedStateBelowOneShouldFail() {
+        CircuitBreakerConfig.custom().ringBufferSizeInHalfClosedState(0).build();
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -64,7 +64,7 @@ public class CircuitBreakerConfigTest {
     public void shouldSetDefaultSettings() {
         CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.ofDefaults();
         then(circuitBreakerConfig.getFailureRateThreshold()).isEqualTo(50);
-        then(circuitBreakerConfig.getRingBufferSizeInHalfOpenState()).isEqualTo(10);
+        then(circuitBreakerConfig.getRingBufferSizeInHalfClosedState()).isEqualTo(10);
         then(circuitBreakerConfig.getRingBufferSizeInClosedState()).isEqualTo(100);
         then(circuitBreakerConfig.getWaitDurationInOpenState().getSeconds()).isEqualTo(60);
         then(circuitBreakerConfig.getCircuitBreakerEventListener()).isNotNull();
@@ -85,8 +85,8 @@ public class CircuitBreakerConfigTest {
 
     @Test()
     public void shouldSetRingBufferSizeInHalfOpenState() {
-        CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom().ringBufferSizeInHalfOpenState(100).build();
-        then(circuitBreakerConfig.getRingBufferSizeInHalfOpenState()).isEqualTo(100);
+        CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom().ringBufferSizeInHalfClosedState(100).build();
+        then(circuitBreakerConfig.getRingBufferSizeInHalfClosedState()).isEqualTo(100);
     }
 
     @Test()

--- a/src/test/java/javaslang/circuitbreaker/CircuitBreakerTest.java
+++ b/src/test/java/javaslang/circuitbreaker/CircuitBreakerTest.java
@@ -39,7 +39,7 @@ public class CircuitBreakerTest {
         // Create a custom configuration for a CircuitBreaker
         CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
                 .ringBufferSizeInClosedState(2)
-                .ringBufferSizeInHalfOpenState(2)
+                .ringBufferSizeInHalfClosedState(2)
                 .failureRateThreshold(50)
                 .waitDurationInOpenState(Duration.ofMillis(1000))
                 .build();
@@ -87,7 +87,7 @@ public class CircuitBreakerTest {
         // Given
         CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
                 .ringBufferSizeInClosedState(2)
-                .ringBufferSizeInHalfOpenState(2)
+                .ringBufferSizeInHalfClosedState(2)
                 .waitDurationInOpenState(Duration.ofMillis(1000))
                 .recordFailure(throwable -> Match.of(throwable)
                         .whenType(IOException.class).then(false)

--- a/src/test/java/javaslang/circuitbreaker/internal/CircuitBreakerStateMachineTest.java
+++ b/src/test/java/javaslang/circuitbreaker/internal/CircuitBreakerStateMachineTest.java
@@ -37,7 +37,7 @@ public class CircuitBreakerStateMachineTest {
         circuitBreaker = new CircuitBreakerStateMachine("testName", CircuitBreakerConfig.custom()
                 .failureRateThreshold(50)
                 .ringBufferSizeInClosedState(5)
-                .ringBufferSizeInHalfOpenState(2)
+                .ringBufferSizeInHalfClosedState(2)
                 .waitDurationInOpenState(Duration.ofSeconds(1))
                 .build());
     }

--- a/src/test/java/javaslang/reactivestreams/ReactiveStreamsTest.java
+++ b/src/test/java/javaslang/reactivestreams/ReactiveStreamsTest.java
@@ -39,8 +39,7 @@ import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.*;
 
 public class ReactiveStreamsTest {
 
@@ -60,7 +59,7 @@ public class ReactiveStreamsTest {
         circuitBreakerRegistry = CircuitBreakerRegistry.of(new CircuitBreakerConfig.Builder()
                 .failureRateThreshold(50)
                 .ringBufferSizeInClosedState(2)
-                .ringBufferSizeInHalfOpenState(2)
+                .ringBufferSizeInHalfClosedState(2)
                 .waitDurationInOpenState(Duration.ofMillis(1000))
                 .build());
     }


### PR DESCRIPTION
Renamed "HalfOpen" to "HalfClosed" everywhere in code (methods, variables etc.) and documentation to match the State.HALF_CLOSED value.