### PR TITLE
Fix to allow retry durations over 10 ms

### DIFF
--- a/src/main/java/javaslang/retry/RetryContext.java
+++ b/src/main/java/javaslang/retry/RetryContext.java
@@ -93,8 +93,8 @@ public class RetryContext implements Retry {
         }
 
         public Builder waitDuration(Duration waitDuration) {
-            if (waitDuration.getSeconds() < 0.01) {
-                throw new IllegalArgumentException("waitDurationInOpenState must be at least than 10[ms]");
+            if (waitDuration.toMillis() < 10) {
+                throw new IllegalArgumentException("waitDurationInOpenState must be at least 10ms");
             }
             this.waitDuration = waitDuration;
             return this;

--- a/src/test/java/javaslang/retry/RetryBuilderTest.java
+++ b/src/test/java/javaslang/retry/RetryBuilderTest.java
@@ -22,6 +22,8 @@ import org.junit.Test;
 
 import java.time.Duration;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class RetryBuilderTest {
 
     @Test(expected = IllegalArgumentException.class)
@@ -32,5 +34,22 @@ public class RetryBuilderTest {
     @Test(expected = IllegalArgumentException.class)
     public void zeroWaitIntervalShouldFail() {
         Retry.custom().waitDuration(Duration.ofMillis(0)).build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void WaitIntervalUnderTenMillisShouldFail() {
+        Retry.custom().waitDuration(Duration.ofMillis(5)).build();
+    }
+
+    @Test
+    public void waitIntervalOfTenMillisShouldSucceed() {
+        Retry retryCtx = Retry.custom().waitDuration(Duration.ofMillis(10)).build();
+        assertThat(retryCtx).isNotNull();
+    }
+
+    @Test
+    public void waitIntervalOverTenMillisShouldSucceed() {
+        Retry retryCtx = Retry.custom().waitDuration(Duration.ofSeconds(10)).build();
+        assertThat(retryCtx).isNotNull();
     }
 }


### PR DESCRIPTION
The validation logic on custom `RetryContext` wait duration contains a casting bug which prevents wait durations under one second from being specified. This is because `duration.getSeconds()` returns a `long` -- which is always zero for durations under one second.