### PR TITLE
Retry: sleep fixes and tests

### DIFF
--- a/src/main/java/javaslang/retry/RetryContext.java
+++ b/src/main/java/javaslang/retry/RetryContext.java
@@ -22,7 +22,7 @@ public class RetryContext implements Retry {
 
     private RetryContext(int maxAttempts, Duration waitDuration, Predicate<Throwable> exceptionPredicate){
         this.maxAttempts = maxAttempts;
-        this.waitDuration = waitDuration.getSeconds() * 1000;
+        this.waitDuration = waitDuration.toMillis();
         this.exceptionPredicate = exceptionPredicate;
         this.numOfAttempts = new AtomicInteger(0);
         this.lastException = new AtomicReference<>();

--- a/src/test/java/javaslang/retry/RunnableRetryTest.java
+++ b/src/test/java/javaslang/retry/RunnableRetryTest.java
@@ -35,12 +35,13 @@ import static org.mockito.Mockito.times;
 public class RunnableRetryTest {
 
     private HelloWorldService helloWorldService;
+    private long sleptTime = 0L;
 
     @Before
     public void setUp(){
         helloWorldService = mock(HelloWorldService.class);
+        RetryContext.sleepFunction = sleep -> sleptTime += sleep;
     }
-
 
     @Test
     public void shouldNotRetry() {
@@ -55,6 +56,7 @@ public class RunnableRetryTest {
         BDDMockito.then(helloWorldService).should(times(1)).sayHelloWorld();
         // and the result should be a success
         assertThat(result.isSuccess()).isTrue();
+        assertThat(sleptTime).isEqualTo(0);
     }
 
     @Test
@@ -76,6 +78,7 @@ public class RunnableRetryTest {
         assertThat(result.isFailure()).isTrue();
         // and the returned exception should be of type RuntimeException
         assertThat(result.failed().get()).isInstanceOf(WebServiceException.class);
+        assertThat(sleptTime).isEqualTo(RetryContext.DEFAULT_WAIT_DURATION*2);
     }
 
     @Test
@@ -97,6 +100,7 @@ public class RunnableRetryTest {
         assertThat(result.isFailure()).isTrue();
         // and the returned exception should be of type RuntimeException
         assertThat(result.failed().get()).isInstanceOf(WebServiceException.class);
+        assertThat(sleptTime).isEqualTo(0);
     }
 
     @Test
@@ -122,5 +126,6 @@ public class RunnableRetryTest {
         assertThat(result.isFailure()).isTrue();
         // and the returned exception should be of type RuntimeException
         assertThat(result.failed().get()).isInstanceOf(WebServiceException.class);
+        assertThat(sleptTime).isEqualTo(0);
     }
 }

--- a/src/test/java/javaslang/retry/SupplierRetryTest.java
+++ b/src/test/java/javaslang/retry/SupplierRetryTest.java
@@ -37,10 +37,12 @@ import static org.mockito.Mockito.times;
 public class SupplierRetryTest {
 
     private HelloWorldService helloWorldService;
+    private long sleptTime = 0L;
 
     @Before
     public void setUp(){
         helloWorldService = mock(HelloWorldService.class);
+        RetryContext.sleepFunction = sleep -> sleptTime += sleep;
     }
 
     @Test
@@ -59,6 +61,7 @@ public class SupplierRetryTest {
         // and the result should be a success
         assertThat(result.isSuccess()).isTrue();
         assertThat(result.get()).isEqualTo("Hello world");
+        assertThat(sleptTime).isEqualTo(0);
     }
 
     @Test
@@ -77,6 +80,7 @@ public class SupplierRetryTest {
         // Then the helloWorldService should be invoked 2 times
         BDDMockito.then(helloWorldService).should(times(2)).returnHelloWorld();
         assertThat(result.get()).isEqualTo("Hello world");
+        assertThat(sleptTime).isEqualTo(RetryContext.DEFAULT_WAIT_DURATION);
     }
 
     @Test
@@ -98,6 +102,7 @@ public class SupplierRetryTest {
         assertThat(result.isFailure()).isTrue();
         // and the returned exception should be of type RuntimeException
         assertThat(result.failed().get()).isInstanceOf(WebServiceException.class);
+        assertThat(sleptTime).isEqualTo(RetryContext.DEFAULT_WAIT_DURATION*2);
     }
 
     @Test
@@ -119,6 +124,7 @@ public class SupplierRetryTest {
         assertThat(result.isFailure()).isTrue();
         // and the returned exception should be of type RuntimeException
         assertThat(result.failed().get()).isInstanceOf(WebServiceException.class);
+        assertThat(sleptTime).isEqualTo(0);
     }
 
     @Test
@@ -144,6 +150,7 @@ public class SupplierRetryTest {
         assertThat(result.isFailure()).isTrue();
         // and the returned exception should be of type RuntimeException
         assertThat(result.failed().get()).isInstanceOf(WebServiceException.class);
+        assertThat(sleptTime).isEqualTo(0);
     }
 
     @Test
@@ -164,6 +171,7 @@ public class SupplierRetryTest {
 
         // and the returned exception should be of type RuntimeException
         assertThat(result.get()).isEqualTo("Hello world from recovery function");
+        assertThat(sleptTime).isEqualTo(RetryContext.DEFAULT_WAIT_DURATION*2);
     }
 
 }


### PR DESCRIPTION
so the Retry mechanism only respected waiting times at the second granularity (!!!). The first commit fixes that.
The second commit makes the sleeping function overrideable by the tests and the tests do override it and check the sleep times to make sure they are as expected. Notice that the change also speeds up the tests after the first commit, since after that first commit they start sleeping by amounts of 500ms.